### PR TITLE
Docker image awscli switch and SIGTERM logging

### DIFF
--- a/minecraft-ecsfargate-watchdog/Dockerfile
+++ b/minecraft-ecsfargate-watchdog/Dockerfile
@@ -1,14 +1,10 @@
-# version 1.0.3
+# version 1.1.0
 # docker pull doctorray/minecraft-ecsfargate-watchdog
 
-FROM ubuntu:20.04
+FROM amazon/aws-cli
 
-RUN apt-get update
-RUN apt-get install -y curl unzip less net-tools coreutils jq gawk
-RUN apt-get dist-upgrade -u -y
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-RUN unzip awscliv2.zip
-RUN ./aws/install
+RUN yum install -y net-tools jq && \
+    yum clean all
 
 COPY ./watchdog.sh .
 

--- a/minecraft-ecsfargate-watchdog/watchdog.sh
+++ b/minecraft-ecsfargate-watchdog/watchdog.sh
@@ -33,8 +33,13 @@ function zero_service ()
   exit 0
 }
 
-## upon SIGTERM set the service desired count to zero
-trap zero_service SIGTERM
+function sigterm ()
+{
+  ## upon SIGTERM set the service desired count to zero
+  echo "Received SIGTERM, terminating task..."
+  zero_service
+}
+trap sigterm SIGTERM
 
 ## get task id from the Fargate metadata
 TASK=$(curl -s ${ECS_CONTAINER_METADATA_URI_V4}/task | jq -r '.TaskARN' | awk -F/ '{ print $NF }')


### PR DESCRIPTION
Couple of small changes initially:

- Switched to awscli image for smaller footprint, and ARM64 support (in lieu of Fargate supporting this yet)
- Log when we receive a SIGTERM (clarifies issues seen in #5)