### PR TITLE
README.md: warn users about Task Execution Role

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ Create a new Task Definition of `FARGATE` launch type.  In the configuration wiz
 - Task Definition Name: `minecraft-server`
 - Task Role: `ecs.task.minecraft-server`
 - Network Mode: `awsvpc` (default)
-- Task Execution Role: `Create new role` (default if you've never created tasks before) or `ecsTaskExecutionRole` (default otherwise)
+- Task Execution Role: `Create new role` (default if you've never created tasks before) or `ecsTaskExecutionRole` (default otherwise). Not to be confused with Task Role. Do NOT select `ecs.task.minecraft-server` here.
 - Task Memory: `2GB` (good to start, increase later if needed)
 - Task CPU: `1 vCPU` (good to start, increase later if needed)
 


### PR DESCRIPTION
It is possible that users may confuse `ecsTaskExecutionRole` with
`ecs.task.minecraft-server`. Warn explicitly so that these kinds
of mistakes can be avoided.