### PR TITLE
Update IP address on shutdown

### DIFF
--- a/minecraft-ecsfargate-watchdog/watchdog.sh
+++ b/minecraft-ecsfargate-watchdog/watchdog.sh
@@ -28,7 +28,28 @@ function send_notification ()
 function zero_service ()
 {
   send_notification shutdown
-  echo Setting desired task count to zero.
+  echo Setting desired task count to zero & updating ip
+  cat << EOF >> minecraft-dns.json
+{
+  "Comment": "Fargate Public IP change for Minecraft Server",
+  "Changes": [
+    {
+      "Action": "UPSERT",
+      "ResourceRecordSet": {
+        "Name": "$SERVERNAME",
+        "Type": "A",
+        "TTL": 30,
+        "ResourceRecords": [
+          {
+            "Value": "0.0.0.0"
+          }
+        ]
+      }
+    }
+  ]
+}
+EOF
+  aws route53 change-resource-record-sets --hosted-zone-id $DNSZONE --change-batch file://minecraft-dns.json
   aws ecs update-service --cluster $CLUSTER --service $SERVICE --desired-count 0
   exit 0
 }


### PR DESCRIPTION
Untested, but update IP when shutting down to one that another minecraft instance might be assigned next time the domain is requested.

The concern is that the domain continues to point to an ip address someone else could be assigned. An initial query would point to the wrong server, and if it was running a minecraft server as well, possibly a very confused user trying to connect to their normal server. This attempts to assign an invalid ip to the record on shutdown to remove that risk.

Feel free to change. Wasn't sure if indenting would effect the cat method, so left indenting the same as the copied section.