### PR TITLE
Memory defaults to 1G unless env variable is set.

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ Under `Advanced container configuration` make these changes:
   - UNCHECK `Essential` (the watchdog container handles shutdowns)
   - Environment Variables.  One gotcha,  you have to select "Value" from the drop down list when defining these.
     - `EULA` : `TRUE`
+    - `MEMORY` : `2G`
     - Any additional stuff you want from [Minecraft Java Docker Server Docs] or [Minecraft Bedrock Docker Server Docs]
 - Storage and Logging
   - Mount Points


### PR DESCRIPTION
I noticed after deploying this service that the minecraft docker container server will default to using 1G even if more memory is available. Setting the env variable fixes this.