### PR TITLE
Add a little detail to the up/down notifications

### DIFF
--- a/minecraft-ecsfargate-watchdog/watchdog.sh
+++ b/minecraft-ecsfargate-watchdog/watchdog.sh
@@ -11,8 +11,8 @@
 
 function send_notification ()
 {
-  [ "$1" = "startup" ] && MESSAGETEXT="Minecraft container online"
-  [ "$1" = "shutdown" ] && MESSAGETEXT="Shutting down Minecraft Server"
+  [ "$1" = "startup" ] && MESSAGETEXT="${SERVICE} is online at ${SERVERNAME}"
+  [ "$1" = "shutdown" ] && MESSAGETEXT="Shutting down ${SERVICE} at ${SERVERNAME}"
 
   ## Twilio Option
   [ -n "$TWILIOFROM" ] && [ -n "$TWILIOTO" ] && [ -n "$TWILIOAID" ] && [ -n "$TWILIOAUTH" ] && \


### PR DESCRIPTION
If folks make use of more than one `minecraft-ondemand` instance or generally prefer more info, it could be helpful to have the service and server names in the up/down notifications.  Here I've done a basic implementation of that.