### PR TITLE
fix: specify amd64 target platform for watchdog image

### DIFF
--- a/cdk/lib/minecraft-stack.ts
+++ b/cdk/lib/minecraft-stack.ts
@@ -223,9 +223,13 @@ export class MinecraftStack extends Stack {
       'WatchDogContainer',
       {
         containerName: constants.WATCHDOG_SERVER_CONTAINER_NAME,
-        image: ecs.ContainerImage.fromRegistry(
-            'doctorray/minecraft-ecsfargate-watchdog'
-        ),
+        image: isDockerInstalled()
+          ? ecs.ContainerImage.fromAsset(
+              path.resolve(__dirname, '../../minecraft-ecsfargate-watchdog/')
+            )
+          : ecs.ContainerImage.fromRegistry(
+              'doctorray/minecraft-ecsfargate-watchdog'
+            ),
         essential: true,
         taskDefinition: taskDefinition,
         environment: {

--- a/cdk/lib/minecraft-stack.ts
+++ b/cdk/lib/minecraft-stack.ts
@@ -223,13 +223,9 @@ export class MinecraftStack extends Stack {
       'WatchDogContainer',
       {
         containerName: constants.WATCHDOG_SERVER_CONTAINER_NAME,
-        image: isDockerInstalled()
-          ? ecs.ContainerImage.fromAsset(
-              path.resolve(__dirname, '../../minecraft-ecsfargate-watchdog/')
-            )
-          : ecs.ContainerImage.fromRegistry(
-              'doctorray/minecraft-ecsfargate-watchdog'
-            ),
+        image: ecs.ContainerImage.fromRegistry(
+            'doctorray/minecraft-ecsfargate-watchdog'
+        ),
         essential: true,
         taskDefinition: taskDefinition,
         environment: {

--- a/minecraft-ecsfargate-watchdog/Dockerfile
+++ b/minecraft-ecsfargate-watchdog/Dockerfile
@@ -1,7 +1,7 @@
 # version 1.2.0
 # docker pull doctorray/minecraft-ecsfargate-watchdog
 
-FROM amazon/aws-cli
+FROM --platform=linux/amd64 amazon/aws-cli
 
 RUN yum install -y net-tools jq nmap-ncat && \
     yum clean all


### PR DESCRIPTION
# Description
Specifies what CPU architecture the image should be built for.  This change sets the target platform to match the [default Fargate task definition](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#runtime-platform) CPU architecture. I have tested watchdog build using an ARM64 system, with working server results.

# Related
I believe this resolves the following issues:
- #27 
- #43

# Disclosure
While I don't believe this should be a breaking change, **I have not tested build from non-arm64 system**.