### PR TITLE
Allow watchdog to listen to bedrock port if using geyser

### DIFF
--- a/cdk/.env.sample
+++ b/cdk/.env.sample
@@ -25,4 +25,5 @@ TWILIO_AUTH_CODE              =
 
 DEBUG = false
 CDK_NEW_BOOTSTRAP = 1
+USE_GEYSER = false
 

--- a/cdk/README.md
+++ b/cdk/README.md
@@ -93,8 +93,9 @@ set in `.env`.
 | TWILIO_AUTH_CODE              | Twilio auth code.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | --                   |
 | DEBUG                         | Enables debug mode.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | --                   |
 | CDK_NEW_BOOTSTRAP             | Addresses issue for some users relating to AWS move to bootstrap v2.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | `1`                  |
+| USE_GEYSER             | Allows watchdog to listen to bedrock port if using geyser | `false`                  |
 
-## Cleanup
+## **Cleanup**
 
 To remove all of the resources that were deployed on the deploy script run the following command:
 

--- a/cdk/lib/config.ts
+++ b/cdk/lib/config.ts
@@ -44,4 +44,5 @@ export const resolveConfig = (): StackConfig => ({
     authCode: process.env.TWILIO_AUTH_CODE || '',
   },
   debug: stringAsBoolean(process.env.DEBUG) || false,
+  useGeyser: stringAsBoolean(process.env.USE_GEYSER) || false,
 });

--- a/cdk/lib/minecraft-stack.ts
+++ b/cdk/lib/minecraft-stack.ts
@@ -244,6 +244,7 @@ export class MinecraftStack extends Stack {
           TWILIOAUTH: config.twilio.authCode,
           STARTUPMIN: config.startupMinutes,
           SHUTDOWNMIN: config.shutdownMinutes,
+          GEYSER: config.useGeyser.toString(),
         },
         logging: config.debug
           ? new ecs.AwsLogDriver({

--- a/cdk/lib/types.ts
+++ b/cdk/lib/types.ts
@@ -145,6 +145,14 @@ export interface StackConfig {
    * - CloudWatch Logs for the `minecraft-ecsfargate-watchdog` ECS Container
    */
   debug: boolean;
+  /**
+   * Setting to `true` will allow the watchdog to listen for geyser connections.
+   * Make sure to set `BEDROCK_SERVER_PORT` to your geyser port if it's not the default (`19132`).
+   *
+   * @default false
+   * @example true
+   */
+  useGeyser: boolean;
 }
 
 export interface MinecraftEditionConfig {

--- a/minecraft-ecsfargate-watchdog/watchdog.sh
+++ b/minecraft-ecsfargate-watchdog/watchdog.sh
@@ -134,7 +134,7 @@ CONNECTED=0
 while [ $CONNECTED -lt 1 ]
 do
   echo Waiting for connection, minute $COUNTER out of $STARTUPMIN...
-  [ "$EDITION" == "java" ] && CONNECTIONS_JAVA=$(netstat -atn | grep :19132 | grep ESTABLISHED | wc -l)
+  [ "$EDITION" == "java" ] && CONNECTIONS_JAVA=$(netstat -atn | grep :25565 | grep ESTABLISHED | wc -l)
   [[ "$EDITION" == "bedrock" || "$GEYSER" == true ]] && CONNECTIONS_BEDROCK=$( (echo -en "$BEDROCKPING" && sleep 1) | ncat -w 1 -u 127.0.0.1 19132 | cut -c34- | awk -F\; '{ print $5 }')
   [ -n "$CONNECTIONS_JAVA" ] || CONNECTIONS_JAVA=0
   [ -n "$CONNECTIONS_BEDROCK" ] || CONNECTIONS_BEDROCK=0
@@ -157,7 +157,7 @@ echo "We believe a connection has been made, switching to shutdown watcher."
 COUNTER=0
 while [ $COUNTER -le $SHUTDOWNMIN ]
 do
-  [ "$EDITION" == "java" ] && CONNECTIONS_JAVA=$(netstat -atn | grep :19132 | grep ESTABLISHED | wc -l)
+  [ "$EDITION" == "java" ] && CONNECTIONS_JAVA=$(netstat -atn | grep :25565 | grep ESTABLISHED | wc -l)
   [[ "$EDITION" == "bedrock" || "$GEYSER" == true ]] && CONNECTIONS_BEDROCK=$( (echo -en "$BEDROCKPING" && sleep 1) | ncat -w 1 -u 127.0.0.1 19132 | cut -c34- | awk -F\; '{ print $5 }')
   [ -n "$CONNECTIONS_JAVA" ] || CONNECTIONS_JAVA=0
   [ -n "$CONNECTIONS_BEDROCK" ] || CONNECTIONS_BEDROCK=0

--- a/minecraft-ecsfargate-watchdog/watchdog.sh
+++ b/minecraft-ecsfargate-watchdog/watchdog.sh
@@ -8,6 +8,8 @@
 [ -n "$DNSZONE" ] || { echo "DNSZONE env variable must be set to the Route53 Hosted Zone ID" ; exit 1; }
 [ -n "$STARTUPMIN" ] || { echo "STARTUPMIN env variable not set, defaulting to a 10 minute startup wait" ; STARTUPMIN=10; }
 [ -n "$SHUTDOWNMIN" ] || { echo "SHUTDOWNMIN env variable not set, defaulting to a 20 minute shutdown wait" ; SHUTDOWNMIN=20; }
+[ -n "$GEYSER" ] || { echo "GEYSER env variable not set, defaulting to false" ; GEYSER=false; }
+
 
 function send_notification ()
 {
@@ -113,7 +115,7 @@ then
   done
 fi
 
-if [ "$EDITION" == "bedrock" ]
+if [[ "$EDITION" == "bedrock" || "$GEYSER" == true ]]
 then
   PINGA="\x01" ## uncommitted ping
   PINGB="\x00\x00\x00\x00\x00\x00\x4e\x20" ## time since start in ms.  20 seconds sounds good
@@ -132,10 +134,11 @@ CONNECTED=0
 while [ $CONNECTED -lt 1 ]
 do
   echo Waiting for connection, minute $COUNTER out of $STARTUPMIN...
-  [ "$EDITION" == "java" ] && CONNECTIONS=$(netstat -atn | grep :25565 | grep ESTABLISHED | wc -l)
-  [ "$EDITION" == "bedrock" ] && CONNECTIONS=$((echo -en "$BEDROCKPING" && sleep 1) | ncat -w 1 -u 127.0.0.1 19132 | cut -c34- | awk -F\; '{ print $5 }')
-  [ -n "$CONNECTIONS" ] || CONNECTIONS=0
-  CONNECTED=$(($CONNECTED + $CONNECTIONS))
+  [ "$EDITION" == "java" ] && CONNECTIONS_JAVA=$(netstat -atn | grep :19132 | grep ESTABLISHED | wc -l)
+  [[ "$EDITION" == "bedrock" || "$GEYSER" == true ]] && CONNECTIONS_BEDROCK=$( (echo -en "$BEDROCKPING" && sleep 1) | ncat -w 1 -u 127.0.0.1 19132 | cut -c34- | awk -F\; '{ print $5 }')
+  [ -n "$CONNECTIONS_JAVA" ] || CONNECTIONS_JAVA=0
+  [ -n "$CONNECTIONS_BEDROCK" ] || CONNECTIONS_BEDROCK=0
+  CONNECTED=$(($CONNECTED + $CONNECTIONS_JAVA + $CONNECTIONS_BEDROCK))
   COUNTER=$(($COUNTER + 1))
   if [ $CONNECTED -gt 0 ] ## at least one active connection detected, break out of loop
   then
@@ -154,10 +157,11 @@ echo "We believe a connection has been made, switching to shutdown watcher."
 COUNTER=0
 while [ $COUNTER -le $SHUTDOWNMIN ]
 do
-  [ "$EDITION" == "java" ] && CONNECTIONS=$(netstat -atn | grep :25565 | grep ESTABLISHED | wc -l)
-  [ "$EDITION" == "bedrock" ] && CONNECTIONS=$((echo -en "$BEDROCKPING" && sleep 1) | ncat -w 1 -u 127.0.0.1 19132 | cut -c34- | awk -F\; '{ print $5 }')
-  [ -n "$CONNECTIONS" ] || CONNECTIONS=0
-  if [ $CONNECTIONS -lt 1 ]
+  [ "$EDITION" == "java" ] && CONNECTIONS_JAVA=$(netstat -atn | grep :19132 | grep ESTABLISHED | wc -l)
+  [[ "$EDITION" == "bedrock" || "$GEYSER" == true ]] && CONNECTIONS_BEDROCK=$( (echo -en "$BEDROCKPING" && sleep 1) | ncat -w 1 -u 127.0.0.1 19132 | cut -c34- | awk -F\; '{ print $5 }')
+  [ -n "$CONNECTIONS_JAVA" ] || CONNECTIONS_JAVA=0
+  [ -n "$CONNECTIONS_BEDROCK" ] || CONNECTIONS_BEDROCK=0
+  if [ $CONNECTIONS_JAVA -lt 1 ] && [ $CONNECTIONS_BEDROCK -lt 1 ]
   then
     echo "No active connections detected, $COUNTER out of $SHUTDOWNMIN minutes..."
     COUNTER=$(($COUNTER + 1))


### PR DESCRIPTION
This should fix https://github.com/doctorray117/minecraft-ondemand/issues/58, where the watchdog closes the server if it's a Java server using Geyser plugin and the online players are connecting using the Bedrock edition.

I've published a watchdog container to test. You can replace `doctorray/minecraft-ecsfargate-watchdog` on `minecraft-stack.ts` with `yurisasc/minecraft-ecsfargate-watchdog`.

I'm currently still testing the container itself. Any help will be appreciated.