### PR TITLE
Fix typo in cdk readme

### DIFF
--- a/cdk/README.md
+++ b/cdk/README.md
@@ -5,7 +5,7 @@
 
 # Introduction
 
-Cloud Development Kit (CDK) is a relatively easy way to deploy infrastructure as code.  Within the context of this project, this is a CDK implementation of almonst all of the required items to bring up and operate this project with some customizations.  This guide is built for beginners and is tailored toward a Windows experience.  Advanced or Linux users can gloss over the stuff that doesn't apply to them.
+Cloud Development Kit (CDK) is a relatively easy way to deploy infrastructure as code.  Within the context of this project, this is a CDK implementation of almost all of the required items to bring up and operate this project with some customizations.  This guide is built for beginners and is tailored toward a Windows experience.  Advanced or Linux users can gloss over the stuff that doesn't apply to them.
 
 # Quickest Start (Windows)
 Linux friends should be able to adapt this to their needs.


### PR DESCRIPTION
This is rad, thanks for making it! Found a small typo:

"almonst" -> "almost"