### PR TITLE
Update watchdog.sh to wait STARTUPMIN for port listen

### DIFF
--- a/minecraft-ecsfargate-watchdog/watchdog.sh
+++ b/minecraft-ecsfargate-watchdog/watchdog.sh
@@ -88,7 +88,7 @@ do
   netstat -aun | grep :19132 && EDITION="bedrock" && break
   sleep 1
   COUNTER=$(($COUNTER + 1))
-  if [ $COUNTER -gt 600 ] ## server has not been detected as starting within 10 minutes
+  if [ $COUNTER -gt $STARTUPMIN ] ## server has not been detected as starting within $STARTUPMIN minutes
   then
     echo 10 minutes elapsed without a minecraft server listening, terminating.
     zero_service


### PR DESCRIPTION
Adjust MC version checker to wait for $STARTUPMIN minutes, as if server does not listen until started, it will always be terminated before listening on its respective port, making the STARTUPMIN env variable nonfunctional.